### PR TITLE
Link ranked list to graph

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,6 +24,8 @@
   <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
   {% endif %}
 
+  <script src="{{ site.baseurl }}/js/common.js"></script>
+
   {% if page.useColorBrewer %}
   <script src="{{ site.baseurl }}/js/colorbrewer.js"></script>
   {% endif %}

--- a/_sass/_ranked-list.scss
+++ b/_sass/_ranked-list.scss
@@ -1,0 +1,40 @@
+/**
+ * Ranked list SCSS
+ */
+#candidates {
+	font-family: Arial, sans-serif;
+
+	#settings {
+		display: inline-block;
+		border-radius: 10px;
+		border-color: #008cba
+	}
+
+	.pz {
+		color: red;
+	}
+
+	ol {
+		display: inline-block;
+		border-top: 2em;
+
+		li {
+			border-left: 1px solid $grey-color;
+			margin: 10px;
+			padding: 7px;
+			border-radius: 8px 8px 0;
+			border-bottom: 2px solid $grey-color;
+
+			.stats {
+				float: right;
+				text-align: right;
+			}
+
+			a {
+				@extend button;
+			}
+
+			@extend %clearfix;
+		}
+	}
+}

--- a/_sass/_ranked-list.scss
+++ b/_sass/_ranked-list.scss
@@ -14,6 +14,11 @@
 		color: red;
 	}
 
+	.build-link {
+		/* link not yet ready */
+		display: none;
+	}
+
 	ol {
 		display: inline-block;
 		border-top: 2em;

--- a/_sass/_visualize.scss
+++ b/_sass/_visualize.scss
@@ -1,30 +1,8 @@
 /**
  * Visualization CSS
  */
-#svg-container, #candidates {
+#svg-container {
 	font-family: Arial, sans-serif;
-
-}
-
-#candidates {
-	#settings {
-		display: inline-block;
-		border-radius: 10px;
-		border-color: #008cba
-	}
-
-	ol {
-		display: inline-block;
-		border-top: 2em;
-
-		li {
-			border-left: 1px solid $grey-color;
-			margin: 5px;
-			padding: 5px;
-			border-radius: 8px 8px 0;
-			border-bottom: 2px solid $grey-color;
-		}
-	}
 }
 
 #graph {
@@ -39,7 +17,6 @@ g {
 .pz {
 	fill: "red";
 	fill-opacity: 0.5;
-	color: red;
 }
 
 .pz-hidden .pz {

--- a/_sass/_visualize.scss
+++ b/_sass/_visualize.scss
@@ -19,12 +19,17 @@ g {
 	fill-opacity: 0.5;
 }
 
-.pz-hidden .pz {
-	display: none;
-}
-
 .not-pz {
 	fill-opacity: 0.1;
+}
+
+.green {
+	fill: "green";
+	fill-opacity: 0.3;
+}
+
+.pz-hidden .pz {
+	display: none;
 }
 
 .tooltip {

--- a/css/main.scss
+++ b/css/main.scss
@@ -54,5 +54,6 @@ $on-laptop:        800px;
 		"layout",
 		"syntax-highlighting",
 		"visualize",
-		"promise-zone-builder"
+		"promise-zone-builder",
+		"ranked-list"
 ;

--- a/js/builder.js
+++ b/js/builder.js
@@ -1,26 +1,3 @@
-// Creates an object from URL encoded data
-function createObjFromURI() {
-   	var uri = decodeURI(location.hash.substr(1));
-   	var chunks = uri.split('&');
-   	var params = Object();
-   	var param_name = ""
-   	console.log("Running createObjFromURI " + chunks.length);
-    for (var i=0; i < chunks.length ; i++) {
-   	    var chunk = chunks[i].split('=');
-       	if(chunk[0].search("\\[\\]") !== -1) {
-       		param_name = chunk[0].split('[]')[0]
-           	if( typeof params[param_name] === 'undefined' ) {
-               	params[param_name] = [chunk[1]];
-            } else {
-           	params[param_name].push(chunk[1]);
-        	}
-        } else {
-   	        params[chunk[0]] = chunk[1];
-       	}
-    }
-   	return params;
-}
-
 function getCountiesFromURI() {
 	console.log("Running getCountiesFromURI");
 	var uriObj = createObjFromURI();

--- a/js/common.js
+++ b/js/common.js
@@ -1,0 +1,21 @@
+// Creates an object from URL encoded data
+function createObjFromURI() {
+	var uri = decodeURI(location.hash.substr(1));
+	var chunks = uri.split('&');
+	var params = {};
+
+	for (var i=0; i < chunks.length; i++) {
+		var chunk = chunks[i].split('=');
+		if (chunk[0].search("\\[\\]") !== -1) {
+			var param_name = chunk[0].split('[]')[0];
+			if (typeof params[param_name] === 'undefined') {
+				params[param_name] = [chunk[1]];
+			} else {
+				params[param_name].push(chunk[1]);
+			}
+		} else {
+			params[chunk[0]] = chunk[1];
+		}
+	}
+	return params;
+}

--- a/js/graph.js
+++ b/js/graph.js
@@ -8,6 +8,11 @@ var opts = {
 	usePythagoras = true;
 
 function draw(data) {
+	var params = createObjFromURI();
+
+	// Which one should be green
+	var greenDot = params.fips_id ? params.fips_id : null;
+
 	d3.selection.prototype.moveToFront = function() {
 		return this.each(function(){
 			this.parentNode.appendChild(this);
@@ -51,13 +56,22 @@ function draw(data) {
 		.insert("circle")
 		.attr("cx", function(d) { return xRange (d.ue_rate); })
 		.attr("cy", function(d) { return yRange (d.pv_rate); })
-		.attr("r", function(d) { if (d.pz) { return 6; } else { return 4; } })
+		.attr("r", function(d) {
+			if (d.fips_id == greenDot) {
+				return 10;
+			}
+			return d.pz ? 6 : 4;
+		})
 		.classed('pz', function(d) { return d.pz; })
 		.classed('not-pz', function(d) { return !d.pz; })
+		.classed('green', function(d) { return d.fips_id == greenDot; })
 		.style("fill", function(d) {
 			if (d.pz) {
 				return "red";
 			} else {
+				if (greenDot == d.fips_id) {
+					return "green";
+				}
 				return "blue";
 			}
 		})
@@ -68,7 +82,16 @@ function draw(data) {
 			div	.html(d.area_name + "<br/>Unemployment: "  + d3.format(".1%")(d.ue_rate) + " Poverty: " + d3.format(".1%")(d.pv_rate))
 				.style("left", (d3.event.pageX) + "px")
 				.style("top", (d3.event.pageY - 28) + "px")
-				.style("background", function() { if (d.pz) { return "pink"; } else { return "lightsteelblue"; } });
+				.style("background", function() {
+					if (d.pz) {
+						return "pink";
+					} else {
+						if (d.fips_id == greenDot) {
+							return 'lightgreen';
+						}
+						return "lightsteelblue";
+					}
+				});
 		})
 		.on("mouseout", function(d) {
 			div.transition()

--- a/js/rank.js
+++ b/js/rank.js
@@ -1,5 +1,22 @@
 var candidates = {
+	areasUrl: 'https://raw.githubusercontent.com/promise-zones/promise-zones/master/areas.json',
 	data: [],
+
+	tpl: null,
+
+	init: function () {
+		// Populate the template used for each ranked item
+		this.tpl = $('#empty').html();
+		var self = this;
+		$.getJSON(
+			this.areasUrl,
+			function (data) {
+				self.data = data;
+				self.rank();
+			}
+		);
+	},
+
 	rank: function() {
 		var xWeight = $('#xWeight').val();
 		var yWeight = $('#yWeight').val();
@@ -18,6 +35,7 @@ var candidates = {
 		});
 		$('#candidates ol').empty();
 		var soFar = 0;
+		var visLink = '', buildLink = '';
 		// now list out the top 50 or so
 		for (var i = 0; soFar < count; i++) {
 			if (i > this.data.length) {
@@ -33,13 +51,28 @@ var candidates = {
 			// @todo: Maybe figure out way to color these on the chart dynamically (so when weights change, it
 			// updates)
 			var liClass = d.pz ? 'pz' : 'not-pz';
-			$('#candidates ol').append($(
-				'<li class="' + liClass + '">'+
-					d.area_name +
-					'<br>Unemployment: ' + candidates.percentFormat(d.ue_rate) +
-					' Poverty: ' + candidates.percentFormat(d.pv_rate) +
-				'</li>'
-			));
+			var entry = $('<li>' + this.tpl + '</li>');
+			entry.find('.area-name').text(d.area_name);
+			entry.find('.ue-rate').text(this.percentFormat(d.ue_rate));
+			entry.find('.pv-rate').text(this.percentFormat(d.pv_rate));
+			entry.find('.pop').text(this.numberFormat(d.pop));
+			if (d.fips_id) {
+				if (!visLink) {
+					// set it first time in loop
+					visLink = entry.find('.vis-link').attr('href');
+					buildLink = entry.find('.build-link').attr('href');
+					console.log('visLink', visLink);
+				}
+				entry.find('.vis-link').prop('href', visLink + d.fips_id);
+				// TODO: update build link
+			} else {
+				// Cannot link if do not have fips_id so hide links
+				entry.find('.links').hide();
+			}
+			// show or hide the pz text
+			entry.find('.pz')[d.pz ? 'show' : 'hide']();
+
+			$('#candidates ol').append(entry);
 			soFar++;
 		}
 	},
@@ -48,17 +81,16 @@ var candidates = {
 		return (Math.round(amount * 1000) / 10) + '%';
 	},
 
+	numberFormat: function (amount) {
+		amount = '' + amount;
+		return amount.replace(/(\d)(?=(\d\d\d)+(?!\d))/g, "$1,");
+	},
+
 	toggleSettings: function () {
 		$('#settings, #settingsToggle').toggle();
 	}
 };
 
 $(function () {
-	$.getJSON(
-		'https://raw.githubusercontent.com/promise-zones/promise-zones/master/areas.json',
-		function (data) {
-			candidates.data = data;
-			candidates.rank();
-		}
-	);
+	candidates.init();
 });

--- a/ranked-list.html
+++ b/ranked-list.html
@@ -32,5 +32,21 @@ pageJs: rank
 		</label>
 	</fieldset>
 	<br>
-	<ol></ol>
+	<ol>
+		<li></li>
+	</ol>
+	<div id="empty" style="display: none;">
+		<span class="stats">
+			Unemployment: <span class="ue-rate"></span><br>
+			Poverty: <span class="pv-rate"></span><br>
+			Population: <span class="pop"></span>
+		</span>
+		<span class="area-name"></span>
+		<br>
+		<span class="links">
+			<a class="vis-link" href="{{ site.baseurl }}/visualize.html#fips_id=">Graph</a>
+			<a class="build-link" href="{{ site.baseurl }}/promise-zone-builder.html#">Build</a>
+		</span>
+		<span class="pz">Promise Zone</span>
+	</div>
 </div>


### PR DESCRIPTION
This adds link to graph from the ranked list.
- Moves some CSS and JS around, previously some of the stuff for the ranked list was on same files for visualize graph
- Makes the list a lot better looking
- Adds link to "graph"
- On graph, make dot green if it matches with fips_id in the URL

**TODO:**
- Link to zone builder
- link from zone builder to graph
- link from zone builder to ranked list
- Look into linking from graph to other 2 locations - not sure how easy would be with current way the hover tooltip works, will have to play with it
